### PR TITLE
fix ConfigParser for python 3.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ matrix:
           env: SETUP_CMD='test'
         - python: 3.4
           env: SETUP_CMD='test'
+        - python: 3.5
+          env: SETUP_CMD='test'
 
         # Try older numpy versions
         - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 2.7
     - 3.3
     - 3.4
+    - 3.5
     # This is just for "egg_info".  All other builds are explicitly given in the matrix
 env:
     global:

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,11 @@ from astropy_helpers.git_helpers import get_git_devstr
 from astropy_helpers.version_helpers import generate_version_py
 
 # Get some values from the setup.cfg
-from distutils import config
-conf = config.ConfigParser()
+try:
+    from configparser import ConfigParser       #- python 3.5
+except ImportError:
+    from distutils.config import ConfigParser   #- python 2.7
+conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
 


### PR DESCRIPTION
This PR fixes the setup.py ConfigParser to work with python 3.5.2, and enables python 3.5 in the Travis tests.  I see that 3.3 and 3.4 were already included in the Travis tests; I'm not sure why this didn't come up before.  Without this fix, I get the following error when running "python setup.py test" using anaconda python 3.5.2:
```
Traceback (most recent call last):
  File "setup.py", line 25, in <module>
    conf = config.ConfigParser()
AttributeError: module 'distutils.config' has no attribute 'ConfigParser'
```
The location of ConfigParser has apparently moved; this fix supports both 2.7 and 3.5, and presumably those versions in between (Travis will be testing those ... but why did this previously break on 3.x?)