### PR TITLE
added more resolution to wavelength writing

### DIFF
--- a/speclite/filters.py
+++ b/speclite/filters.py
@@ -853,7 +853,7 @@ class FilterResponse(object):
             directory_name,
             '{0}-{1}.ecsv'.format(
                 self.meta['group_name'], self.meta['band_name']))
-        table.write(name, format='ascii.ecsv')
+        table.write(name, format='ascii.ecsv',formats={'wavelength':'%.5f'})
         return os.path.abspath(name)
 
 

--- a/speclite/filters.py
+++ b/speclite/filters.py
@@ -853,7 +853,7 @@ class FilterResponse(object):
             directory_name,
             '{0}-{1}.ecsv'.format(
                 self.meta['group_name'], self.meta['band_name']))
-        table.write(name, format='ascii.ecsv',formats={'wavelength':'%.5f'})
+        table.write(name, format='ascii.ecsv',formats={'wavelength': repr, 'response': repr})
         return os.path.abspath(name)
 
 


### PR DESCRIPTION
When reading from the SVO filter library and then saving those filters to .ecsv files, the resolution was causing duplication of some wavelengths. Therefore, speclite was not able to read them back in. 

I have simply added a formator in the save procedure to keep the resolution in the saved files a little finer.

We are making this a dependency in out fitting framework (https://github.com/giacomov/3ML) and will be using the save feature extensively, so it would be nice if this gets pushed to pip :)