### PR TITLE
Add BASS and MzLS filter groups

### DIFF
--- a/speclite/filters.py
+++ b/speclite/filters.py
@@ -11,7 +11,7 @@ with a hyphen, e.g. "sdss2010-r".  The group names included with this package
 are:
 
     >>> filter_group_names
-    ['sdss2010', 'decam2014', 'wise2010', 'hsc2017', 'lsst2016', 'bessell']
+    ['sdss2010', 'decam2014', 'wise2010', 'hsc2017', 'lsst2016', 'bessell', 'BASS', 'MzLS']
 
 List the band names associated with any group using, for example:
 
@@ -245,7 +245,8 @@ import astropy.utils.data
 
 
 filter_group_names = [
-    'sdss2010', 'decam2014', 'wise2010', 'hsc2017', 'lsst2016', 'bessell']
+    'sdss2010', 'decam2014', 'wise2010', 'hsc2017', 'lsst2016', 'bessell',
+    'BASS', 'MzLS']
 
 default_wavelength_unit = astropy.units.Angstrom
 


### PR DESCRIPTION
dkirkby/speclite#37 added BASS and MzLS filters, but forgot to add them to the `speclite.filters.filter_group_name` list which is apparently required for actually loading the filters.  This PR adds those.