### PR TITLE
slice with tuples not arrays

### DIFF
--- a/speclite/filters.py
+++ b/speclite/filters.py
@@ -1463,7 +1463,7 @@ class FilterConvolution(object):
                 .format(len(self._wavelength), axis))
         values_slice = [slice(None)] * len(values_no_units.shape)
         values_slice[axis] = self._response_slice
-        values_no_units = values_no_units[values_slice]
+        values_no_units = values_no_units[tuple(values_slice)]
 
         if plot:
             if len(values_no_units.shape) != 1:
@@ -1517,7 +1517,7 @@ class FilterConvolution(object):
                 (integrand, interpolated_integrand), axis=axis)
             # Resort by wavelength.
             values_slice[axis] = self.interpolate_sort_order
-            integrand = integrand[values_slice]
+            integrand = integrand[tuple(values_slice)]
 
         if plot:
             # Plot integrand before applying weights, so we can re-use


### PR DESCRIPTION
Recent versions of numpy generate a FutureWarning on speclite tests:
```
[...]/speclite/filters.py:1520: FutureWarning:
Using a non-tuple sequence for multidimensional indexing is deprecated;
use `arr[tuple(seq)]` instead of `arr[seq]`.
In the future this will be interpreted as an array index, `arr[np.array(seq)]`,
which will result either in an error or a different result.
    integrand = integrand[values_slice]
```
This PR follows that advice to use `arr[tuple(seq)]` in two places.